### PR TITLE
Add tests for SXTH, LDRSH and STRH

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -10,6 +10,7 @@ static unsigned int test_counter = 0;
 static TestCaller tests[] = {
     FS::TestAll,
     CPU::Integer::TestAll,
+    CPU::Memory::TestAll,
     Kernel::TestAll,
 };
 

--- a/source/tests/cpu/cputests.h
+++ b/source/tests/cpu/cputests.h
@@ -1,7 +1,6 @@
 #pragma once
 
 namespace CPU {
-namespace Integer {
-void TestAll();
-}
+    namespace Integer { void TestAll(); }
+    namespace Memory { void TestAll(); }
 }

--- a/source/tests/cpu/integer.cpp
+++ b/source/tests/cpu/integer.cpp
@@ -218,6 +218,33 @@ static bool Usada8() {
     return true;
 }
 
+// SXTH
+static bool Sxth() {
+    unsigned int output = 50;
+
+    // No rotation
+    output = 0x0000FFCE;
+    asm volatile ("SXTH %[out], %[out]" : [out] "+r"(output));
+    SoftAssert(output == (u32)-50);
+
+    // ROR by 8
+    output = 0x00FCE000;
+    asm volatile ("SXTH %[out], %[out], ROR #8" : [out] "+r"(output));
+    SoftAssert(output == (u32)-800);
+
+    // ROR by 16
+    output = 0x01410000;
+    asm volatile ("SXTH %[out], %[out], ROR #16" : [out] "+r"(output));
+    SoftAssert(output == (u32)321);
+
+    // ROR by 24
+    output = 0xCE0000FF;
+    asm volatile ("SXTH %[out], %[out], ROR #24" : [out] "+r"(output));
+    SoftAssert(output == (u32)-50);
+
+    return true;
+}
+
 // UXTAB16
 static bool Uxtab16() {
     unsigned int output;
@@ -284,6 +311,7 @@ void TestAll() {
     Test(tag, "UQSUB8", Uqsub8(), true);
     Test(tag, "USAD8", Usad8(), true);
     Test(tag, "USADA8", Usada8(), true);
+    Test(tag, "SXTH", Sxth(), true);
     Test(tag, "UXTAB16", Uxtab16(), true);
     Test(tag, "UXTB16", Uxtb16(), true);
 }

--- a/source/tests/cpu/memory.cpp
+++ b/source/tests/cpu/memory.cpp
@@ -1,0 +1,39 @@
+#include <limits>
+#include <string>
+#include "output.h"
+#include "common/string_funcs.h"
+#include "tests/test.h"
+
+namespace CPU {
+namespace Memory {
+
+// LDRSH
+static bool Ldrsh() {
+    u32 input = 0x0000F5E3;
+    u32 output;
+    asm volatile ("LDRSH %[out], %[in]" : [out] "=r"(output) : [in] "m"(input));
+    SoftAssert(output == 0xFFFFF5E3);
+
+    return true;
+}
+
+// STRH
+static bool Strh() {
+    u32 input = 0xFFFFF5E3;
+    u32 output[2] = { 0x12121212, 0x12121212 };
+    asm volatile ("STRH %[in], %[out]" : [out] "+m"(output[0]) : [in] "r"(input) : "memory");
+    SoftAssert(output[0] == 0x1212F5E3);
+    SoftAssert(output[1] == 0x12121212);
+
+    return true;
+}
+
+void TestAll() {
+    const std::string tag = "Memory";
+
+    Test(tag, "LDRSH", Ldrsh(), true);
+    Test(tag, "STRH",  Strh(),  true);
+}
+
+}
+}


### PR DESCRIPTION
All tests pass on both Citra and the 3DS. I created these while investigating the pad issue and there's really no reason not to include them here.