### PR TITLE
Fixed accessing uninitialized memory in the memory fill tests.

### DIFF
--- a/source/tests/gpu/displaytransfer.cpp
+++ b/source/tests/gpu/displaytransfer.cpp
@@ -45,8 +45,8 @@ union Dimensions {
 };
 
 static void DisplayTransferAndWait(u32* input, u32* output, Dimensions input_dimensions, Dimensions output_dimensions, u32 flags) {
-    GSPGPU_FlushDataCache(input, sizeof(u32));
-    GSPGPU_InvalidateDataCache(output, sizeof(u32));
+    GSPGPU_FlushDataCache(input, 0x4000 * sizeof(u32));
+    GSPGPU_InvalidateDataCache(output, 0x4000 * sizeof(u32));
     Result res = GX_DisplayTransfer(input, input_dimensions.raw, output, output_dimensions.raw, flags);
     if ((u32)res != 0) {
         Log(Common::FormatString("Something went wrong: %u\n", (u32)res));

--- a/source/tests/gpu/memoryfills.cpp
+++ b/source/tests/gpu/memoryfills.cpp
@@ -30,9 +30,6 @@ static bool Fill32Bits(u8* buffer) {
     TestEquals(buffer[5], 0xFFu);
     TestEquals(buffer[6], 0xFFu);
     TestEquals(buffer[7], 0x00u);
-    TestEquals(buffer[48], 0x00u);
-    TestEquals(buffer[49], 0x00u);
-    TestEquals(buffer[49], 0x00u);
 
     FillAndWait(buffer, 0x0000FFFF, 48, 0x201, false);
     TestEquals(buffer[0], 0xFFu);
@@ -57,9 +54,6 @@ static bool Fill24Bits(u8* buffer) {
     TestEquals(buffer[5], 0xFFu);
     TestEquals(buffer[6], 0xFFu);
     TestEquals(buffer[7], 0xFFu);
-    TestEquals(buffer[48], 0x00u);
-    TestEquals(buffer[49], 0x00u);
-    TestEquals(buffer[49], 0x00u);
 
     FillAndWait(buffer, 0xFFFFFFFF, 48, 0x101);
     TestEquals(buffer[0], 0xFFu);


### PR DESCRIPTION
Also flush and invalidate the right amount of bytes during each memory transfer test.

With this, all hwtests pass on real hardware.